### PR TITLE
Error on missing licenses

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,4 @@ cp dist/traefik ${PREFIX}/bin
 
 go-licenses save \
     "." \
-    --save_path "${SRC_DIR}/library_licenses/" \
-    2>&1 \
-    | tee "${SRC_DIR}/go-licenses.log" \
-    || echo "some errors: captured in go-licenses.log"
+    --save_path "${SRC_DIR}/library_licenses/"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     sha256: eb4694ef72a8356a2acf36315e5e141027001c1eef8acade7ecb86512305d286
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -34,7 +34,6 @@ about:
   license_file:
     - src/{{ gomodule }}/LICENSE.md
     - library_licenses/
-    - go-licenses.log
 
   summary: The Cloud Native Application Proxy
 


### PR DESCRIPTION
It doesn't seem like any errors currently happen; thus I remove the `|| …` in general here.